### PR TITLE
Remove inclusion of inexistent folders and the example

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,20 +6,13 @@
 
 fx_version 'cerulean'
 
-games { 'gta5' };
+games { 'gta5' }
 
 client_scripts {
-	"src/RageUI.lua",
-	"src/Menu.lua",
-	"src/MenuController.lua",
-	"src/components/*.lua",
-	"src/elements/*.lua",
-	"src/items/*.lua",
-	"src/panels/*.lua",
-	"src/windows/*.lua",
-	"example.lua"
+    'src/RageUI.lua',
+    'src/Menu.lua',
+    'src/MenuController.lua',
+    'src/components/*.lua',
+    'src/elements/*.lua',
+    'src/items/*.lua',
 }
-
-
-
-


### PR DESCRIPTION
- Remove the inclusion lines from the folders that do not exist
- Remove the default inclusion from the example